### PR TITLE
Display snoozed windows as grouped entries in manage view

### DIFF
--- a/src/hooks/useDelayedTabsStorage.ts
+++ b/src/hooks/useDelayedTabsStorage.ts
@@ -1,0 +1,80 @@
+import { DelayedTab } from '@types';
+import normalizeDelayedTabs from '@utils/normalizeDelayedTabs';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+interface UseDelayedTabsStorageResult {
+  delayedTabs: DelayedTab[];
+  setDelayedTabs: Dispatch<SetStateAction<DelayedTab[]>>;
+  loading: boolean;
+  reload: () => Promise<void>;
+}
+
+export default function useDelayedTabsStorage(): UseDelayedTabsStorageResult {
+  const [delayedTabs, setDelayedTabs] = useState<DelayedTab[]>([]);
+  const [loading, setLoading] = useState(true);
+  const isMountedRef = useRef(true);
+
+  const loadDelayedTabs = useCallback(async () => {
+    try {
+      if (isMountedRef.current) {
+        setLoading(true);
+      }
+
+      const { delayedTabs: storedTabs = [] } = await chrome.storage.local.get(
+        'delayedTabs'
+      );
+      const normalizedTabs = normalizeDelayedTabs(storedTabs);
+      const sortedTabs = [...normalizedTabs].sort(
+        (a, b) => a.wakeTime - b.wakeTime
+      );
+
+      if (isMountedRef.current) {
+        setDelayedTabs(sortedTabs);
+      }
+    } catch (error) {
+      if (isMountedRef.current) {
+        console.error('Error loading delayed tabs:', error);
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    loadDelayedTabs();
+
+    const handleStorageChange = (
+      changes: Record<string, chrome.storage.StorageChange>,
+      areaName: string
+    ): void => {
+      if (areaName === 'local' && changes.delayedTabs) {
+        void loadDelayedTabs();
+      }
+    };
+
+    chrome.storage.onChanged.addListener(handleStorageChange);
+
+    return () => {
+      isMountedRef.current = false;
+      chrome.storage.onChanged.removeListener(handleStorageChange);
+    };
+  }, [loadDelayedTabs]);
+
+  return {
+    delayedTabs,
+    setDelayedTabs,
+    loading,
+    reload: loadDelayedTabs,
+  };
+}

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -110,6 +110,7 @@
     "wakeUp": "Wake Up",
     "remove": "Remove",
     "untitledTab": "Untitled tab",
+    "windowGroup": "Window • {{count}} tabs",
     "actions": "Actions"
   },
   "donation": {

--- a/src/i18n/locales/es/translation.json
+++ b/src/i18n/locales/es/translation.json
@@ -110,6 +110,7 @@
     "wakeUp": "Despertar",
     "remove": "Eliminar",
     "untitledTab": "Pestaña sin título",
+    "windowGroup": "Ventana • {{count}} pestañas",
     "actions": "Acciones"
   },
   "donation": {

--- a/src/i18n/locales/pt/translation.json
+++ b/src/i18n/locales/pt/translation.json
@@ -110,6 +110,7 @@
     "wakeUp": "Acordar",
     "remove": "Remover",
     "untitledTab": "Aba sem título",
+    "windowGroup": "Janela • {{count}} abas",
     "actions": "Ações"
   },
   "donation": {

--- a/src/pages/popup/views/CustomDelayView.tsx
+++ b/src/pages/popup/views/CustomDelayView.tsx
@@ -86,6 +86,9 @@ function CustomDelayView(): React.ReactElement {
 
     const wakeTime = new Date(customDate).getTime();
 
+    const windowSessionId =
+      selectedMode === 'window' ? generateUniqueTabId() : undefined;
+
     if (
       typeof chrome !== 'undefined' &&
       chrome.storage &&
@@ -107,10 +110,12 @@ function CustomDelayView(): React.ReactElement {
             favicon: tab.favIconUrl,
             createdAt: Date.now(),
             wakeTime,
+            windowSessionId,
+            windowIndex: typeof tab.index === 'number' ? tab.index : undefined,
           };
 
           delayedTabs.push(tabInfo);
-          
+
           if (chrome.alarms) {
             await chrome.alarms.create(`delayed-tab-${tabInfo.id}`, {
               when: wakeTime,

--- a/src/pages/popup/views/MainView.tsx
+++ b/src/pages/popup/views/MainView.tsx
@@ -394,6 +394,9 @@ function MainView(): React.ReactElement {
     const tabsToDelay = getTabsToDelay();
     if (tabsToDelay.length === 0) return;
 
+    const windowSessionId =
+      selectedMode === 'window' ? generateUniqueTabId() : undefined;
+
     let wakeTime: number;
     if (option.calculateTime) {
       wakeTime = option.calculateTime();
@@ -421,10 +424,12 @@ function MainView(): React.ReactElement {
           favicon: tab.favIconUrl,
           createdAt: Date.now(),
           wakeTime,
+          windowSessionId,
+          windowIndex: typeof tab.index === 'number' ? tab.index : undefined,
         };
 
         delayedTabs.push(tabInfo);
-        
+
         await chrome.alarms.create(`delayed-tab-${tabInfo.id}`, {
           when: wakeTime,
         });

--- a/src/pages/popup/views/ManageTabsView.tsx
+++ b/src/pages/popup/views/ManageTabsView.tsx
@@ -2,15 +2,22 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from '@tanstack/react-router';
 import { DelayedTab } from '@types';
 import normalizeDelayedTabs from '@utils/normalizeDelayedTabs';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import useTheme from '../../../utils/useTheme';
 
+type TabGroup = {
+  id: string;
+  wakeTime: number;
+  isWindowGroup: boolean;
+  tabs: DelayedTab[];
+};
+
 function ManageTabsView(): React.ReactElement {
   const [delayedTabs, setDelayedTabs] = useState<DelayedTab[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedTabs, setSelectedTabs] = useState<string[]>([]);
+  const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [selectMode, setSelectMode] = useState(false);
   const { theme, toggleTheme } = useTheme();
   const { t } = useTranslation();
@@ -35,71 +42,158 @@ function ManageTabsView(): React.ReactElement {
     loadDelayedTabs();
   }, []);
 
-  const wakeTabNow = async (tab: DelayedTab): Promise<void> => {
-    try {
-      if (tab.url) {
-        await chrome.tabs.create({ url: tab.url });
-        const updatedTabs = delayedTabs.filter((item) => item.id !== tab.id);
-        await chrome.storage.local.set({ delayedTabs: updatedTabs });
-        await chrome.alarms.clear(`delayed-tab-${tab.id}`);
-        setDelayedTabs(updatedTabs);
-        setSelectedTabs(prev => prev.filter(id => id !== tab.id));
+  const tabGroups = useMemo<TabGroup[]>(() => {
+    const groupMap = new Map<string, TabGroup>();
+    const groups: TabGroup[] = [];
+
+    delayedTabs.forEach((tab) => {
+      const key = tab.windowSessionId
+        ? `${tab.windowSessionId}-${tab.wakeTime}`
+        : tab.id;
+
+      let group = groupMap.get(key);
+
+      if (!group) {
+        group = {
+          id: key,
+          wakeTime: tab.wakeTime,
+          isWindowGroup: Boolean(tab.windowSessionId),
+          tabs: [],
+        };
+        groupMap.set(key, group);
+        groups.push(group);
       }
+
+      group.tabs.push(tab);
+    });
+
+    groups.forEach((group) => {
+      if (group.isWindowGroup) {
+        group.tabs.sort(
+          (a, b) => (a.windowIndex ?? 0) - (b.windowIndex ?? 0)
+        );
+      }
+    });
+
+    return groups;
+  }, [delayedTabs]);
+
+  const collectTabIds = (groupId: string): string[] => {
+    const group = tabGroups.find((item) => item.id === groupId);
+    if (!group) {
+      return [];
+    }
+
+    return group.tabs.map((tab) => tab.id);
+  };
+
+  const wakeGroupNow = async (groupId: string): Promise<void> => {
+    try {
+      const tabIds = collectTabIds(groupId);
+
+      if (tabIds.length === 0) {
+        return;
+      }
+
+      await chrome.runtime.sendMessage({
+        action: 'wake-tabs',
+        tabIds,
+      });
+
+      const updatedTabs = delayedTabs.filter(
+        (item) => !tabIds.includes(item.id)
+      );
+
+      setDelayedTabs(updatedTabs);
+      setSelectedGroupIds((prev) =>
+        prev.filter((id) => id !== groupId)
+      );
     } catch (error) {
-      console.error('Error waking tab:', error);
+      console.error('Error waking group:', error);
     }
   };
 
-  const removeTab = async (tab: DelayedTab): Promise<void> => {
+  const removeGroup = async (groupId: string): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter((item) => item.id !== tab.id);
+      const tabIds = collectTabIds(groupId);
+
+      if (tabIds.length === 0) {
+        return;
+      }
+
+      const updatedTabs = delayedTabs.filter(
+        (item) => !tabIds.includes(item.id)
+      );
+
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
-      await chrome.alarms.clear(`delayed-tab-${tab.id}`);
+      await Promise.all(
+        tabIds.map((tabId) => chrome.alarms.clear(`delayed-tab-${tabId}`))
+      );
+
       setDelayedTabs(updatedTabs);
-      setSelectedTabs(prev => prev.filter(id => id !== tab.id));
+      setSelectedGroupIds((prev) =>
+        prev.filter((id) => id !== groupId)
+      );
     } catch (error) {
-      console.error('Error removing tab:', error);
+      console.error('Error removing group:', error);
     }
   };
-  
+
   const toggleSelectMode = (): void => {
-    setSelectMode(!selectMode);
-    if (selectMode) {
-      setSelectedTabs([]);
-    }
+    setSelectMode((prev) => {
+      if (prev) {
+        setSelectedGroupIds([]);
+      }
+
+      return !prev;
+    });
   };
 
   const toggleSelectAll = (): void => {
-    if (selectedTabs.length === delayedTabs.length) {
-      setSelectedTabs([]);
+    const allSelected =
+      tabGroups.length > 0 &&
+      tabGroups.every((group) => selectedGroupIds.includes(group.id));
+
+    if (allSelected) {
+      setSelectedGroupIds([]);
     } else {
-      setSelectedTabs(delayedTabs.map(tab => tab.id));
+      setSelectedGroupIds(tabGroups.map((group) => group.id));
     }
   };
 
-  const toggleSelectTab = (tabId: string): void => {
-    setSelectedTabs(prev => {
-      if (prev.includes(tabId)) {
-        return prev.filter(id => id !== tabId);
-      } else {
-        return [...prev, tabId];
+  const toggleSelectGroup = (groupId: string): void => {
+    setSelectedGroupIds((prev) => {
+      if (prev.includes(groupId)) {
+        return prev.filter((id) => id !== groupId);
       }
+
+      return [...prev, groupId];
     });
   };
 
   const wakeSelectedTabs = async (): Promise<void> => {
     try {
+      const tabIds = Array.from(
+        new Set(
+          selectedGroupIds.flatMap((groupId) => collectTabIds(groupId))
+        )
+      );
+
+      if (tabIds.length === 0) {
+        return;
+      }
+
       await chrome.runtime.sendMessage({
         action: 'wake-tabs',
-        tabIds: selectedTabs,
+        tabIds,
       });
 
       const updatedTabs = delayedTabs.filter(
-        tab => !selectedTabs.includes(tab.id)
+        (tab) => !tabIds.includes(tab.id)
       );
 
       setDelayedTabs(updatedTabs);
-      setSelectedTabs([]);
+      setSelectedGroupIds([]);
     } catch (error) {
       console.error('Error waking selected tabs:', error);
     }
@@ -107,15 +201,24 @@ function ManageTabsView(): React.ReactElement {
 
   const removeSelectedTabs = async (): Promise<void> => {
     try {
-      const updatedTabs = delayedTabs.filter(tab => !selectedTabs.includes(tab.id));
+      const tabIds = Array.from(
+        new Set(
+          selectedGroupIds.flatMap((groupId) => collectTabIds(groupId))
+        )
+      );
+
+      const updatedTabs = delayedTabs.filter(
+        (tab) => !tabIds.includes(tab.id)
+      );
+
       await chrome.storage.local.set({ delayedTabs: updatedTabs });
 
-      for (const tabId of selectedTabs) {
-        await chrome.alarms.clear(`delayed-tab-${tabId}`);
-      }
+      await Promise.all(
+        tabIds.map((tabId) => chrome.alarms.clear(`delayed-tab-${tabId}`))
+      );
 
       setDelayedTabs(updatedTabs);
-      setSelectedTabs([]);
+      setSelectedGroupIds([]);
     } catch (error) {
       console.error('Error removing selected tabs:', error);
     }
@@ -123,11 +226,11 @@ function ManageTabsView(): React.ReactElement {
 
   const formatDate = (timestamp: number): string => {
     const locale = document.documentElement.lang || navigator.language || 'pt-BR';
-    
+
     const isEnglish = locale.startsWith('en');
-    
+
     const date = new Date(timestamp);
-    
+
     return date.toLocaleString(locale, {
       year: 'numeric',
       month: 'long',
@@ -149,6 +252,10 @@ function ManageTabsView(): React.ReactElement {
     if (hours > 0) return `${hours}h ${minutes}m`;
     return `${minutes}m`;
   };
+
+  const allGroupsSelected =
+    tabGroups.length > 0 &&
+    tabGroups.every((group) => selectedGroupIds.includes(group.id));
 
   if (loading) {
     return (
@@ -189,7 +296,7 @@ function ManageTabsView(): React.ReactElement {
           </button>
         </div>
 
-        {delayedTabs.length === 0 ? (
+        {tabGroups.length === 0 ? (
           <div className='flex flex-col items-center justify-center p-8 text-center'>
             <FontAwesomeIcon
               icon='hourglass-empty'
@@ -211,8 +318,8 @@ function ManageTabsView(): React.ReactElement {
                   onClick={toggleSelectMode}
                   title={selectMode ? t('manageTabs.cancelSelection') : t('manageTabs.selectMode')}
                 >
-                  <FontAwesomeIcon 
-                    icon={selectMode ? 'times' : 'check-square'} 
+                  <FontAwesomeIcon
+                    icon={selectMode ? 'times' : 'check-square'}
                     className='mr-2'
                   />
                   {selectMode ? t('manageTabs.cancel') : t('manageTabs.select')}
@@ -223,11 +330,11 @@ function ManageTabsView(): React.ReactElement {
                     className='btn btn-sm btn-ghost ml-2'
                     onClick={toggleSelectAll}
                   >
-                    {selectedTabs.length === delayedTabs.length ? t('manageTabs.deselectAll') : t('manageTabs.selectAll')}
+                    {allGroupsSelected ? t('manageTabs.deselectAll') : t('manageTabs.selectAll')}
                   </button>
                 )}
               </div>
-              {selectMode && selectedTabs.length > 0 && (
+              {selectMode && selectedGroupIds.length > 0 && (
                 <div className='flex space-x-2'>
                   <button
                     type='button'
@@ -235,77 +342,130 @@ function ManageTabsView(): React.ReactElement {
                     style={{ backgroundColor: '#ffb26f', color: '#3B1B00' }}
                     onClick={wakeSelectedTabs}
                   >
-                    {t('manageTabs.wakeUp')} ({selectedTabs.length})
+                    {t('manageTabs.wakeUp')} ({selectedGroupIds.length})
                   </button>
                   <button
                     type='button'
                     className='btn btn-outline btn-error btn-sm'
                     onClick={removeSelectedTabs}
                   >
-                    {t('manageTabs.remove')} ({selectedTabs.length})
+                    {t('manageTabs.remove')} ({selectedGroupIds.length})
                   </button>
                 </div>
               )}
             </div>
             <div className='space-y-3'>
-              {delayedTabs.map((tab) => (
-                <div
-                  key={tab.id}
-                  className='flex items-center justify-between rounded-lg bg-base-100/70 p-4 shadow-sm transition-all duration-200 hover:bg-base-100'
-                >
-                  <div className='flex items-center'>
-                    {selectMode && (
-                      <div 
-                        className='mr-3 cursor-pointer'
-                        onClick={() => toggleSelectTab(tab.id)}
-                      >
-                        <FontAwesomeIcon 
-                          icon={selectedTabs.includes(tab.id) ? 'check-square' : 'square'} 
-                          className={selectedTabs.includes(tab.id) ? 'text-delayo-orange' : 'text-base-content/50'}
-                          style={{ fontSize: 'large' }}
-                        />
+              {tabGroups.map((group) => {
+                const isSelected = selectedGroupIds.includes(group.id);
+                const primaryTab = group.tabs[0];
+
+                return (
+                  <div
+                    key={group.id}
+                    className='rounded-lg bg-base-100/70 p-4 shadow-sm transition-all duration-200 hover:bg-base-100'
+                  >
+                    <div className='flex items-start justify-between'>
+                      <div className='flex items-start'>
+                        {selectMode && (
+                          <button
+                            type='button'
+                            className='mr-3 mt-1 cursor-pointer text-left'
+                            onClick={() => toggleSelectGroup(group.id)}
+                            aria-pressed={isSelected}
+                          >
+                            <FontAwesomeIcon
+                              icon={isSelected ? 'check-square' : 'square'}
+                              className={isSelected ? 'text-delayo-orange' : 'text-base-content/50'}
+                              style={{ fontSize: 'large' }}
+                            />
+                          </button>
+                        )}
+                        <div className='mr-3 flex h-9 w-9 items-center justify-center rounded-md bg-base-200'>
+                          {group.isWindowGroup ? (
+                            <FontAwesomeIcon
+                              icon='window-restore'
+                              className='text-base-content/70'
+                            />
+                          ) : (
+                            primaryTab?.favicon ? (
+                              <img
+                                src={primaryTab.favicon}
+                                alt='Tab favicon'
+                                className='h-5 w-5 rounded-sm'
+                                onError={(e) => {
+                                  e.currentTarget.style.display = 'none';
+                                }}
+                              />
+                            ) : (
+                              <FontAwesomeIcon
+                                icon='globe'
+                                className='text-base-content/50'
+                              />
+                            )
+                          )}
+                        </div>
+                        <div className='mr-4 max-w-[220px]'>
+                          <div className='truncate text-sm font-medium text-base-content/80'>
+                            {group.isWindowGroup
+                              ? t('manageTabs.windowGroup', {
+                                  count: group.tabs.length,
+                                })
+                              : primaryTab?.title || t('manageTabs.untitledTab')}
+                          </div>
+                          <div className='truncate text-xs text-base-content/60'>
+                            {formatDate(group.wakeTime)} ({calculateTimeLeft(group.wakeTime)})
+                          </div>
+                        </div>
                       </div>
-                    )}
-                    {tab.favicon && (
-                      <img
-                        src={tab.favicon}
-                        alt='Tab favicon'
-                        className='mr-3 h-5 w-5 rounded-sm'
-                        onError={(e) => {
-                          e.currentTarget.style.display = 'none';
-                        }}
-                      />
-                    )}
-                    <div className='mr-4 max-w-[200px]'>
-                      <div className='truncate text-sm font-medium text-base-content/80'>
-                        {tab.title || t('manageTabs.untitledTab')}
-                      </div>
-                      <div className='truncate text-xs text-base-content/60'>
-                        {formatDate(tab.wakeTime)} ({calculateTimeLeft(tab.wakeTime)})
-                      </div>
+                      {!selectMode && (
+                        <div className='flex space-x-2'>
+                          <button
+                            type='button'
+                            className='btn btn-sm'
+                            style={{ backgroundColor: '#ffb26f', color: '#3B1B00' }}
+                            onClick={() => wakeGroupNow(group.id)}
+                          >
+                            {t('manageTabs.wakeUp')}
+                          </button>
+                          <button
+                            type='button'
+                            className='btn btn-outline btn-error btn-sm'
+                            onClick={() => removeGroup(group.id)}
+                          >
+                            {t('manageTabs.remove')}
+                          </button>
+                        </div>
+                      )}
                     </div>
+                    {group.isWindowGroup && (
+                      <div className='mt-3 border-t border-base-200 pt-3'>
+                        <ul className='space-y-2'>
+                          {group.tabs.map((tab) => (
+                            <li
+                              key={tab.id}
+                              className='flex items-center text-xs text-base-content/70'
+                            >
+                              {tab.favicon && (
+                                <img
+                                  src={tab.favicon}
+                                  alt='Tab favicon'
+                                  className='mr-2 h-4 w-4 rounded-sm'
+                                  onError={(e) => {
+                                    e.currentTarget.style.display = 'none';
+                                  }}
+                                />
+                              )}
+                              <span className='truncate'>
+                                {tab.title || t('manageTabs.untitledTab')}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
                   </div>
-                  {!selectMode && (
-                    <div className='flex space-x-2'>
-                      <button
-                        type='button'
-                        className='btn btn-sm'
-                        style={{ backgroundColor: '#ffb26f', color: '#3B1B00' }}
-                        onClick={() => wakeTabNow(tab)}
-                      >
-                        {t('manageTabs.wakeUp')}
-                      </button>
-                      <button
-                        type='button'
-                        className='btn btn-outline btn-error btn-sm'
-                        onClick={() => removeTab(tab)}
-                      >
-                        {t('manageTabs.remove')}
-                      </button>
-                    </div>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}

--- a/src/pages/popup/views/RecurringDelayView.tsx
+++ b/src/pages/popup/views/RecurringDelayView.tsx
@@ -175,6 +175,9 @@ function RecurringDelayView(): React.ReactElement {
       endDate: endDate ? new Date(endDate).getTime() : undefined,
     };
 
+    const windowSessionId =
+      selectedMode === 'window' ? generateUniqueTabId() : undefined;
+
     if (
       typeof chrome !== 'undefined' &&
       chrome.storage &&
@@ -197,10 +200,13 @@ function RecurringDelayView(): React.ReactElement {
             createdAt: Date.now(),
             wakeTime: firstWakeTime.getTime(),
             recurrencePattern,
+            isRecurring: true,
+            windowSessionId,
+            windowIndex: typeof tab.index === 'number' ? tab.index : undefined,
           };
-          
+
           delayedTabs.push(tabInfo);
-          
+
           if (chrome.alarms) {
             await chrome.alarms.create(`delayed-tab-${tabInfo.id}`, {
               when: firstWakeTime.getTime(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,4 +24,6 @@ export interface DelayedTab {
   wakeTime: number;
   isRecurring?: boolean;
   recurrencePattern?: RecurrencePattern;
+  windowSessionId?: string;
+  windowIndex?: number;
 }

--- a/src/utils/fontAwesome.ts
+++ b/src/utils/fontAwesome.ts
@@ -13,6 +13,7 @@ import {
   faGear,
   faHourglassEmpty,
   faHourglassHalf,
+  faGlobe,
   faLeaf,
   faListUl,
   faMoon,
@@ -26,6 +27,7 @@ import {
   faUmbrellaBeach,
   faWater,
   faWind,
+  faWindowRestore,
 } from '@fortawesome/free-solid-svg-icons';
 
 library.add(
@@ -42,6 +44,7 @@ library.add(
   faGear,
   faHourglassEmpty,
   faHourglassHalf,
+  faGlobe,
   faLeaf,
   faListUl,
   faMoon,
@@ -54,5 +57,6 @@ library.add(
   faTree,
   faUmbrellaBeach,
   faWater,
-  faWind
+  faWind,
+  faWindowRestore
 );


### PR DESCRIPTION
## Summary
- group delayed tabs by window session in the popup manage view so whole windows display together with their member list
- adjust selection, wake, and removal logic to operate on grouped window entries
- add localized labels and register new icons used for window and generic tab placeholders

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e1259031688323ad096498b28eb5db